### PR TITLE
Gh pr pre commit check

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,40 @@
+# Copyright 2026 Espressif Systems (Shanghai) PTE LTD
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Pre-commit Hooks
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,4 +5,13 @@ repos:
   - id: astyle_py
     args: ['--astyle-version=3.4.7', '--rules=tools/ci/astyle-rules.yml']
 
+- repo: https://github.com/google/keep-sorted
+  rev: v0.7.1
+  hooks:
+  - id: keep-sorted
 
+- repo: https://github.com/codespell-project/codespell
+  rev: v2.4.1
+  hooks:
+  - id: codespell
+    args: ['--config=.codespellrc', '--write-changes']

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,80 @@
+# Developer Guide
+
+This guide covers the development workflow and tooling for contributors to esp-matter.
+
+## Pre-commit Hooks
+
+The repository uses [pre-commit](https://pre-commit.com/) to run automated checks before each commit. Following hooks are configured:
+
+1. astyle_py — C/C++ Code Formatter
+
+   [astyle_py](https://github.com/espressif/astyle_py) enforces consistent C/C++ formatting.
+   The formatting rules are defined in `tools/ci/astyle-rules.yml`.
+
+2. keep-sorted — Sorted Block Enforcer
+
+   [keep-sorted](https://github.com/google/keep-sorted) is used in documentation and
+   source files to maintain alphabetical ordering of lists and sections.
+
+3. codespell — Spell Checker
+
+   [codespell](https://github.com/codespell-project/codespell) catches common
+   misspellings in source code, documentation, and comments.
+   Configuration is in `.codespellrc`.
+
+### Setup
+
+1. Install pre-commit
+
+```bash
+python3 -m pip install pre-commit
+```
+
+2. Install the hooks
+
+From the repository root:
+
+```bash
+cd $ESP_MATTER_PATH
+pre-commit install
+```
+
+This registers the hooks so they run automatically on `git commit`.
+
+### Usage
+
+Once installed, the hooks run on every `git commit` against the staged files. If a hook reformats a file, the commit is aborted — review the changes, `git add` the updated files, and commit again.
+
+### Running locally
+
+Run all hooks on every file in the repository:
+
+```bash
+pre-commit run --all-files
+```
+
+Run all hooks only on staged files (same as what happens on commit):
+
+```bash
+pre-commit run
+```
+
+Run a specific hook:
+
+```bash
+pre-commit run astyle_py --all-files
+pre-commit run keep-sorted --all-files
+pre-commit run codespell --all-files
+```
+
+Run hooks on specific files:
+
+```bash
+pre-commit run --files path/to/file.cpp path/to/other_file.h
+```
+
+Skip hooks for a one-off commit (not recommended):
+
+```bash
+git commit --no-verify
+```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI/workflow and developer tooling changes only; main risk is new PR check failures or CI noise if hook behavior (especially `codespell --write-changes`) is unexpected.
> 
> **Overview**
> Adds a new GitHub Actions workflow (`.github/workflows/pre-commit.yml`) that runs `pre-commit` on pull requests to `main` and `release/**`, scoped to the PR diff via `--from-ref/--to-ref`.
> 
> Expands `.pre-commit-config.yaml` beyond `astyle_py` to also enforce sorted blocks (`keep-sorted`) and run spell checking with auto-fixes (`codespell --write-changes`), and adds `DEVELOPER_GUIDE.md` documenting how to install and run these hooks locally.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b73bb04811474da18382fa969ef5ce26b9a47fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->